### PR TITLE
Update dependencies and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 sudo: false
 scala:
-- 2.11.11
-- 2.12.4
+- 2.11.12
+- 2.12.5
 jdk:
 - oraclejdk8
 script:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,15 +3,15 @@ import sbt._, Keys._
 object Dependencies {
 
   val AkkaVersion = sys.env.get("AKKA_SERIES") match {
-    case Some("2.5") => "2.5.6"
-    case _ => "2.4.19"
+    case Some("2.5") => "2.5.11"
+    case _ => "2.4.20"
   }
 
-  val AwsSdkVersion = "1.11.226"
+  val AwsSdkVersion = "1.11.311"
 
   val Common = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % AkkaVersion % Provided,
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
       "org.scalatest" %% "scalatest" % "3.0.1" % Test, // ApacheV2
       "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-style
@@ -21,9 +21,9 @@ object Dependencies {
 
   val Kinesis = Seq(
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-kinesis" % AwsSdkVersion, // ApacheV2
-      "com.amazonaws" % "amazon-kinesis-client" % "1.8.8", // Amazon Software License
-      "org.mockito"   % "mockito-core"     % "2.7.11"    % Test // MIT
+      "com.amazonaws" % "aws-java-sdk-kinesis" % AwsSdkVersion % Provided, // ApacheV2
+      "com.amazonaws" % "amazon-kinesis-client" % "1.9.0" % Provided, // Amazon Software License
+      "org.mockito" % "mockito-core" % "2.7.11" % Test // MIT
     )
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.1.2

--- a/src/test/scala/aserralle/akka/stream/kcl/DefaultTestContext.scala
+++ b/src/test/scala/aserralle/akka/stream/kcl/DefaultTestContext.scala
@@ -9,14 +9,12 @@ import java.util.concurrent.{Executors, TimeoutException}
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import com.amazonaws.services.kinesis.AmazonKinesisAsync
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import org.mockito.Mockito.reset
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
 import scala.concurrent.duration._
-import scala.concurrent.{blocking, Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, blocking}
 
 trait DefaultTestContext
     extends BeforeAndAfterAll

--- a/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
+++ b/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
@@ -119,7 +119,7 @@ class KinesisWorkerSourceSourceSpec
       workerFailure: Option[Throwable] = None) {
     protected val worker = org.mockito.Mockito.mock(classOf[Worker])
     val lock = new Semaphore(0)
-    when(worker.run()).then(new Answer[Unit] {
+    when(worker.run()).thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit =
         workerFailure.fold(lock.acquire())(throw _)
     })
@@ -138,7 +138,7 @@ class KinesisWorkerSourceSourceSpec
       KinesisWorkerSource(
         workerBuilder,
         KinesisWorkerSourceSettings(bufferSize = 10,
-                                    terminateStreamGracePeriod = 1 second))
+                                    terminateStreamGracePeriod = 1.second))
         .viaMat(KillSwitches.single)(Keep.right)
         .watchTermination()(Keep.both)
         .toMat(TestSink.probe)(Keep.both)
@@ -177,7 +177,7 @@ class KinesisWorkerSourceSourceSpec
   "KinesisWorker checkpoint Flow " must {
 
     "checkpoint batch of records of different shards" in new KinesisWorkerCheckpointContext {
-      val recordProcessor = new IRecordProcessor(_ => (), 1 second)
+      val recordProcessor = new IRecordProcessor(_ => (), 1.second)
 
       val checkpointerShard1 =
         org.mockito.Mockito.mock(classOf[IRecordProcessorCheckpointer])
@@ -228,7 +228,7 @@ class KinesisWorkerSourceSourceSpec
     }
 
     "not checkpoint the batch if the IRecordProcessor has been shutdown" in new KinesisWorkerCheckpointContext {
-      val recordProcessor = new IRecordProcessor(_ => (), 1 second)
+      val recordProcessor = new IRecordProcessor(_ => (), 1.second)
       recordProcessor.shutdown(
         new ShutdownInput().withShutdownReason(ShutdownReason.TERMINATE))
       val record = org.mockito.Mockito.mock(classOf[Record])
@@ -250,7 +250,7 @@ class KinesisWorkerSourceSourceSpec
     }
 
     "fail with Exception if checkpoint action fails" in new KinesisWorkerCheckpointContext {
-      val recordProcessor = new IRecordProcessor(_ => (), 1 second)
+      val recordProcessor = new IRecordProcessor(_ => (), 1.second)
       val record = org.mockito.Mockito.mock(classOf[Record])
       when(record.getSequenceNumber).thenReturn("1")
       val checkpointer =
@@ -283,7 +283,7 @@ class KinesisWorkerSourceSourceSpec
           KinesisWorkerSource
             .checkpointRecordsFlow(
               KinesisWorkerCheckpointSettings(maxBatchSize = 100,
-                                              maxBatchWait = 500 millis))
+                                              maxBatchWait = 500.millis))
         )
         .toMat(TestSink.probe)(Keep.both)
         .run()


### PR DESCRIPTION
Updates dependencies' versions, notably scala to 2.12.5. Also sets akka-stream and AWS libs to provided. The good news is that the tests are passing. :)
I would love to get feedback on how to integrate this in your publishing flow, especially with regards to cross version support.
Thanks!