### PR TITLE
Use subsequence number in addition to sequence number when checkpointing

### DIFF
--- a/src/main/scala/aserralle/akka/stream/kcl/CommittableRecord.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/CommittableRecord.scala
@@ -7,7 +7,10 @@ package aserralle.akka.stream.kcl
 import akka.Done
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
-import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber
+import com.amazonaws.services.kinesis.clientlibrary.types.{
+  ExtendedSequenceNumber,
+  UserRecord
+}
 import com.amazonaws.services.kinesis.model.Record
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -38,7 +41,13 @@ class CommittableRecord(
 object CommittableRecord {
 
   // Only makes sense to compare Records belonging to the same shard
+  // Records that have been batched by the KCL producer all have the
+  // same sequence number but will differ by subsequence number
   implicit val orderBySequenceNumber: Ordering[CommittableRecord] =
-    Ordering.by(_.sequenceNumber)
+    Ordering[(String, Long)].on(cr ⇒
+      (cr.sequenceNumber, cr.record match {
+        case ur: UserRecord ⇒ ur.getSubSequenceNumber
+        case _ ⇒ 0
+      }))
 
 }


### PR DESCRIPTION
If records have been written to a Kinesis stream using the KPL, then they will have potentially been automatically aggregated. The Kinesis client library will automatically deaggregate the records but, because of the aggregation, all records from the KCL will have the same sequence number. 

Whilst checkpointing, in `KinesisWorkerSource.checkpointRecordsFlow`, the records are grouped by shard and batched and the maximum record in the batch is checkpointed. However, as the current sort only takes into account the sequence number, the first record is considered the maximum and used to checkpoint. This means that the checkpoint set in Dynamo is incorrect.

This PR amends the `Ordering` of the records so that if the records were aggregated by the KPL, the subsequence number from the batch is included in the sort order. This means the last record from the batch is used to checkpoint rather than the first. A test verifies that the behaviour is as expected.