### PR TITLE
return detailed error message than BackpressureTimeout

### DIFF
--- a/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
@@ -5,8 +5,11 @@
 package aserralle.akka.stream.kcl
 
 object Errors {
-  case class WorkerUnexpectedShutdown(cause: Throwable)
-      extends Throwable(cause)
+  sealed class KinesisWorkerSourceError(err: Throwable) extends Throwable(err)
 
-  case class BackpressureTimeout(cause: Throwable) extends Throwable(cause)
+  case class WorkerUnexpectedShutdown(cause: Throwable)
+      extends KinesisWorkerSourceError(cause)
+
+  case class BackpressureTimeout(cause: Throwable)
+      extends KinesisWorkerSourceError(cause)
 }

--- a/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
@@ -4,14 +4,8 @@
 
 package aserralle.akka.stream.kcl
 
-import scala.util.control.NoStackTrace
-
 object Errors {
+  case class WorkerUnexpectedShutdown(cause: Throwable) extends Throwable(cause)
 
-  sealed trait KinesisWorkerSourceError extends NoStackTrace
-  case class WorkerUnexpectedShutdown(cause: Throwable)
-      extends KinesisWorkerSourceError
-
-  case object BackpressureTimeout extends KinesisWorkerSourceError
-
+  case class BackpressureTimeout(cause: Throwable) extends Throwable(cause)
 }

--- a/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/Errors.scala
@@ -5,7 +5,8 @@
 package aserralle.akka.stream.kcl
 
 object Errors {
-  case class WorkerUnexpectedShutdown(cause: Throwable) extends Throwable(cause)
+  case class WorkerUnexpectedShutdown(cause: Throwable)
+      extends Throwable(cause)
 
   case class BackpressureTimeout(cause: Throwable) extends Throwable(cause)
 }

--- a/src/main/scala/aserralle/akka/stream/kcl/scaladsl/KinesisWorkerSource.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/scaladsl/KinesisWorkerSource.scala
@@ -53,7 +53,7 @@ object KinesisWorkerSource {
                     (Exception.nonFatalCatch either Await.result(
                       queue.offer(record),
                       settings.backpressureTimeout) left)
-                      .foreach(_ => queue.fail(BackpressureTimeout))
+                      .foreach(err => queue.fail(BackpressureTimeout(err)))
                     semaphore.release()
                   },
                   settings.terminateStreamGracePeriod

--- a/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
+++ b/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
@@ -202,7 +202,7 @@ class KinesisWorkerSourceSourceSpec
 
       Await.ready(watch, 5.seconds)
       val Failure(exception) = watch.value.get
-      assert(exception == BackpressureTimeout)
+      assert(exception.getCause.getMessage.contains("Futures timed out after [100 milliseconds]"))
 
       killSwitch.shutdown()
     }

--- a/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
+++ b/src/test/scala/aserralle/akka/stream/kcl/KinesisWorkerSourceSourceSpec.scala
@@ -202,7 +202,9 @@ class KinesisWorkerSourceSourceSpec
 
       Await.ready(watch, 5.seconds)
       val Failure(exception) = watch.value.get
-      assert(exception.getCause.getMessage.contains("Futures timed out after [100 milliseconds]"))
+      assert(
+        exception.getCause.getMessage
+          .contains("Futures timed out after [100 milliseconds]"))
 
       killSwitch.shutdown()
     }


### PR DESCRIPTION
There are couple of cases that cause `SourceQueue.offer` to fail, it can be

1. BackpressureTimeout
2. SourceQueue is completed

We need to fail the queue with `err` so developer can understand the exact error message and stack.