### PR TITLE
call checkpoint without arguments when shard has terminated

### DIFF
--- a/src/main/scala/aserralle/akka/stream/kcl/IRecordProcessor.scala
+++ b/src/main/scala/aserralle/akka/stream/kcl/IRecordProcessor.scala
@@ -53,6 +53,7 @@ private[kcl] class IRecordProcessor(
     latestCheckpointer = Some(shutdownInput.getCheckpointer)
     shutdownInput.getShutdownReason match {
       case ShutdownReason.TERMINATE =>
+        shutdownInput.getCheckpointer.checkpoint()
         Thread.sleep(terminateStreamGracePeriod.toMillis)
       case ShutdownReason.ZOMBIE => ()
       case ShutdownReason.REQUESTED => ()


### PR DESCRIPTION
As mentioned in this issue:
https://github.com/aserrallerios/kcl-akka-stream/issues/9