### PR TITLE
fix BackpressureTimeout after checkpoint throw ShutdownException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 - 2.11.12
 - 2.12.7
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - sbt -J-XX:ReservedCodeCacheSize=128m ++$TRAVIS_SCALA_VERSION ";test:compile"
 # make 'git branch' work again


### PR DESCRIPTION
## Which problem does this PR solve?

Fix SourceQueue backpressure when some substreams failed with ShutdownException.

## Steps to reproduce

I'm using 

```
"software.amazon.kinesis" % "amazon-kinesis-client" % "2.1.3"
"software.amazon.awssdk" % "kinesis" % "2.2.0"
"aserrallerios" %% "kcl-akka-stream" % "0.8"
```
and 2 shards kinesis stream

1. Start a application A1 with one KinesisWorkerSource and CheckpointRecordsFlow, at this point, our CheckpointRecordsFlow will have two substreams, each responsible for checkpointing one shard
2. Start another application A2 with one KinesisWorkerSource and CheckpointRecordsFlow, after A2 steal lease from A1, A1 will only responsible for read and checkpoint one shard, the other substream will failed with ShutdownException during checkpoint and get Resume in [here](https://github.com/aserrallerios/kcl-akka-stream/blob/1a9c22d31abff69433209bd6381ce6030c29c2ed/src/main/scala/aserralle/akka/stream/kcl/scaladsl/KinesisWorkerSource.scala#L105-L106)
3. Stop application A2, when A1 start processing two shards, after sometime (when the buffer is full) SourceQueue will start to backpressure and we will get BackpressureTimeout

Here is the minimal [reproduce demo](https://github.com/CatTail/scala-playground/blob/6d2d1773205523a86ba2f19283fa531849a41dc1/src/main/scala/com/example/playground/AkkaStreamErrorHandling.scala#L140-L188)

## Solution

It looks like that failure happened between Broadcast and Zip will result in backpressure even with supervision strategy set to Resume.

The solution is we handle ShutdownException in checkpoint specially and filter those records out later.